### PR TITLE
feat: enable overwriting of environment variables by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
           printenv
 ```
 
-By default, overwriting existing environment variables is disabled. The enable, pass the overwrite argument:-
+By default, overwriting existing environment variables is allowed. To disable, pass the overwrite argument:-
 ```
  steps:
       - uses: actions/checkout@v1
@@ -33,7 +33,7 @@ By default, overwriting existing environment variables is disabled. The enable, 
       - name: set environment variables
         uses: allenevans/set-env@v1.0.0
         with:
-          overwrite: true
+          overwrite: false
           MY_ENV_VAR: 'my value'
 ``` 
 

--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ runs:
 inputs:
   overwrite:
     description: 'Overwrite existing environment variables'
-    default: false
+    default: true
     required: false


### PR DESCRIPTION
Allow environment variables to be overwritten by default. This behaviour is now consistent with the terminal

Closes #2 