### PR TITLE
Update node to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: 'globe'
   color: 'green'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/set-env.js'


### PR DESCRIPTION
Should fix the warning:

>Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: allenevans/set-env@v2.0.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
